### PR TITLE
Update and somewhat future-proof ruby version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7.5-alpine3.15
+FROM ruby:2.7-alpine
 
 RUN apk add --update --no-cache build-base git jq
 


### PR DESCRIPTION
The old ruby version, `2.7.5-alpine3.15` is no longer supported as the ruby minor version has since increased to 2.7.6. Changing it to `2.7-alpine`, both resolves this issue and future-proofs it from any minor version changes in ruby 2.7.x.